### PR TITLE
Fixes Issue #6 (Templates not working with 1.8.0.4)

### DIFF
--- a/src/main/java/com/hydrologis/remarkable/SshHelper.java
+++ b/src/main/java/com/hydrologis/remarkable/SshHelper.java
@@ -104,7 +104,7 @@ public class SshHelper {
     public static void uploadFile( Session session, String localFile, String remoteFile ) throws Exception {
         boolean ptimestamp = true;
         // exec 'scp -t rfile' remotely
-        String command = "scp " + (ptimestamp ? "-p" : "") + " -t " + remoteFile;
+        String command = "scp " + (ptimestamp ? "-p" : "") + " -t \"" + remoteFile+"\"";
         Channel channel = session.openChannel("exec");
         ((ChannelExec) channel).setCommand(command);
 


### PR DESCRIPTION
Adds quotes around path for scp

This is only tested on Mac OSX and should be tested in other environments. The bug is not really related to  1.8.0.4, but found when upgrading to it. If the fix works in other operating system then the same fix might be applied in other places in source.